### PR TITLE
Removed persistent hosting step

### DIFF
--- a/Single-Model-Deployment/Batch-Inference/Batch-Transform-xgboost-high-level-SDK.ipynb
+++ b/Single-Model-Deployment/Batch-Inference/Batch-Transform-xgboost-high-level-SDK.ipynb
@@ -28,7 +28,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "!python -m pip install --upgrade pip --quiet\n",
@@ -295,21 +297,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Deploy the model\n",
-    "instance_count=1,\n",
-    "instance_type=\"ml.m5.4xlarge\"\n",
-    "\n",
-    "predictor = model_predictor.deploy(\n",
-    "        instance_type='ml.m5.4xlarge',\n",
-    "        initial_instance_count=1)\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "nbpresent": {
@@ -344,9 +331,13 @@
     "\n",
     "from sagemaker.transformer import Transformer\n",
     "\n",
-    "sm_transformer = Transformer(model_name=model_name,\n",
-    "                          instance_count=1,\n",
-    "                          instance_type='ml.m4.xlarge')\n",
+    "transformed_output_path = f\"s3://{s3_bucket}/{bucket_prefix}/output\"\n",
+    "\n",
+    "sm_transformer = model_predictor.transformer(instance_count=1,\n",
+    "                                             instance_type='ml.m4.xlarge',\n",
+    "                                             max_payload=1,\n",
+    "                                             max_concurrent_transforms=2,\n",
+    "                                             output_path=transformed_output_path)\n",
     "\n",
     "#Start the Batch Transform job\n",
     "\n",
@@ -397,6 +388,13 @@
     "output_df = get_csv_output_from_s3(sm_transformer.output_path, batch_file_noID)\n",
     "output_df.head(8)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:* 

This Batch Transform Notebook has logic to deploy persistent endpoint prior to invoking transform().  Model class does offer transformer() method to generate Transformer object.

*Description of changes:*

Updated notebook cells to use Model class transformer instead.  Please review this PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
